### PR TITLE
TTS Keeps Playing After Navigating Away from Number Line Fragment

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://zendalona.com/funding.json

--- a/app/src/main/java/com/zendalona/mathmantra/ui/NumberLineFragment.java
+++ b/app/src/main/java/com/zendalona/mathmantra/ui/NumberLineFragment.java
@@ -57,6 +57,9 @@ public class NumberLineFragment extends Fragment {
     public void onPause() {
         super.onPause();
 //        requireActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        if (tts != null) {
+            tts.stopSpeaking();  // Add a stop method in TTSUtility if not present
+        }
     }
 
     @Override
@@ -167,10 +170,12 @@ public class NumberLineFragment extends Fragment {
 //        tts.speak("Click on continue!");
     }
 
-
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        if (tts != null) {
+            tts.shutdown();  // Properly release TTS resources
+        }
         binding = null;
     }
 }

--- a/app/src/main/java/com/zendalona/mathmantra/utils/TTSUtility.java
+++ b/app/src/main/java/com/zendalona/mathmantra/utils/TTSUtility.java
@@ -29,11 +29,12 @@ public class TTSUtility {
         tts.setSpeechRate(rate);
     }
 
-    public void stop() {
-        if (tts != null) {
+    public void stopSpeaking() {
+        if (tts != null && tts.isSpeaking()) {
             tts.stop();
         }
     }
+
 
     public void shutdown() {
         if (tts != null) {


### PR DESCRIPTION
Fix #10: Stop TTS playback when navigating away from NumberLineFragment  

Issue  
- The TTS continues playing even after navigating away from Number Line screen.  
- This happens when the fragment is left without stopping the TTS.  

Solution  
- `tts.stop()` added in `onPause()` to stop speech when the fragment is not active.  
- `tts.shutdown()` added in `onDestroyView()` to release resources.  

Testing  
- Navigated to Number Line screen → TTS plays the question.  
- Pressed back button → TTS stops immediately.  
- No memory leaks or crashes observed.  